### PR TITLE
Fix http_scraper

### DIFF
--- a/tracker.py
+++ b/tracker.py
@@ -89,7 +89,7 @@ class Tracker(object):
             answer_tracker = requests.get(tracker, params=params, timeout=5)
             list_peers = bdecode(answer_tracker.content)
             offset=0
-            if not type(list_peers['peers']) == dict:
+            if not type(list_peers['peers']) == list:
                 '''
                     - Handles bytes form of list of peers
                     - IP address in bytes form:


### PR DESCRIPTION
Downloads didn't work because it was checking for `not a type dict` instead of `not a type list`.  After switching to list, I no longer had issues with all torrents I tested on.